### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 6 * * 3'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   CodeQL-Build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/chaoscommencer/upload-artifact/security/code-scanning/3](https://github.com/chaoscommencer/upload-artifact/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/codeql-analysis.yml`.  
Best fix without changing behavior: define permissions at the workflow root so all jobs inherit them.

For CodeQL scanning, use:
- `contents: read` (minimal repository read access)
- `security-events: write` (required to upload CodeQL results)

This should be inserted after the `on:` triggers block and before `jobs:`. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
