### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -6,6 +6,9 @@
 # We need to make sure the checked-in `index.js` actually matches what we expect it to be.
 name: Check dist/
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/chaoscommencer/upload-artifact/security/code-scanning/1](https://github.com/chaoscommencer/upload-artifact/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is minimally scoped.  
Best fix here: set workflow-level permissions to `contents: read`, which is sufficient for checkout and the read/compare operations in this job, and does not change workflow behavior.

**File to change:** `.github/workflows/check-dist.yml`  
**Region:** after `name:` and before `on:` (workflow root keys).  
**Changes needed:** insert:

```yml
permissions:
  contents: read
```

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
