### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/chaoscommencer/upload-artifact/security/code-scanning/2](https://github.com/chaoscommencer/upload-artifact/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is scoped to least privilege.  
Best fix here is to set workflow-level permissions to:

- `contents: read`

This preserves existing functionality (`actions/checkout` and license checks only require read access) while eliminating reliance on possibly broad defaults.

**File to change:** `.github/workflows/licensed.yml`  
**Region:** near the top-level keys, after `on:` triggers and before `jobs:` (or immediately after `name:`/`on:`).  
No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
